### PR TITLE
Ensure pages scroll to top on navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,12 +7,14 @@ import ContactUs from './Pages/ContactUs/ContactUs';
 import ProductDetails from './Pages/ProductDetails/ProductDetails';
 import CartContextProvider from './Context/CartContext';
 import Checkout from './Pages/Checkout/Checkout';
+import ScrollToTop from './Components/ScrollToTop';
 
 function App() {
 
   return (
     <BrowserRouter>
       <CartContextProvider>
+        <ScrollToTop />
         <Header />
         <Routes>
           <Route path='/' element={<Homepage />}/>

--- a/src/Components/ScrollToTop.jsx
+++ b/src/Components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## Summary
- add a reusable ScrollToTop component that watches the current route
- integrate the ScrollToTop component within the app router so each navigation resets scroll position

## Testing
- npm install *(fails: npm registry returned 403 when fetching eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d98869d9508332bbe0a232bd8152bd